### PR TITLE
Removed unused constant

### DIFF
--- a/lib/orvfms/setup_page.php
+++ b/lib/orvfms/setup_page.php
@@ -78,7 +78,7 @@ function displaySetupPage($mac,&$s20Table,$myUrl){
     $serverDst = $dev['serverDst']; 
     $isSyncTZ = ($serverDst == $dst) && ($tz == $serverTz);
     $isSyncCK = (abs($serverTime - $time) < 5);
-    $isSync = isSyncTZ && $isSyncCK;
+    //$isSync = isSyncTZ && $isSyncCK; 
     if(!$isSyncCK){
         echo '<div style="color:red">Warning: clock seems out of sync!<p></div>';
     }


### PR DESCRIPTION
$isSync It is no longer use following the updates to the time synchronisation code- was causing an error in PHP > 7.2.
Tested and confirmed working.