### PR TITLE
Update orvfms.php

### DIFF
--- a/lib/orvfms/orvfms.php
+++ b/lib/orvfms/orvfms.php
@@ -901,7 +901,7 @@ function setSocketTime($mac,$newTime,&$s20Table){
     //
     $socketTime = $newTime + FROM_CENTURY_TO_EPOCH;  // adjust to 1 jan 1900
     $socketTime = $socketTime + 1; // compensate for delay (roughly)
-    $socketTimeHex = dechex($socketTime);
+    $socketTimeHex = dechex(intval(round($socketTime)));
     $socketTimeHexLE = invertEndian($socketTimeHex);
 
     $msg = MAGIC_KEY."XXXX".SET_TIME.$mac.TWENTIES.FOUR_ZEROS.$socketTimeHexLE;


### PR DESCRIPTION
Socket time sync was broken by a php update.  Added intval() cast to fix php 8.x error (dechex can't convert float now).  This is backwards compatible with php 6 and 7.  No need to check is_int- max time is 1642204800.